### PR TITLE
Rename functions for consistency

### DIFF
--- a/examples/solverdummy/solverdummy.f03
+++ b/examples/solverdummy/solverdummy.f03
@@ -39,13 +39,13 @@ PROGRAM main
         
   CALL precicef_initialize(dtlimit)            
 
-  CALL precicef_action_required(writeInitialData, bool, 50)
+  CALL precicef_is_action_required(writeInitialData, bool, 50)
   IF (bool.EQ.1) THEN
     WRITE (*,*) 'DUMMY: Writing initial data'
   ENDIF
   CALL precicef_initialize_data()
 
-  CALL precicef_ongoing(ongoing)
+  CALL precicef_is_coupling_ongoing(ongoing)
   DO WHILE (ongoing.NE.0)
   
     CALL precicef_action_required(writeItCheckp, bool, 50)
@@ -55,9 +55,9 @@ PROGRAM main
     ENDIF
 
     CALL precicef_advance(dtlimit)
-    CALL precicef_ongoing(ongoing)
+    CALL precicef_is_coupling_ongoing(ongoing)
 
-    CALL precicef_action_required(readItCheckp, bool, 50)
+    CALL precicef_is_action_required(readItCheckp, bool, 50)
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Reading iteration checkpoint'
       CALL precicef_mark_action_fulfilled(readItCheckp, 50)

--- a/precice.f03
+++ b/precice.f03
@@ -50,28 +50,54 @@ module precice
       integer(kind=c_int) :: dimensions
     end subroutine precicef_get_dims
 
+    ! Deprecated - Forwards to precicef_is_coupling_ongoing_
     subroutine precicef_ongoing(isOngoing) &
-      &  bind(c, name='precicef_ongoing_')
+      &  bind(c, name='precicef_is_coupling_ongoing_')
 
       use, intrinsic :: iso_c_binding
       integer(kind=c_int) :: isOngoing
     end subroutine precicef_ongoing
+
+    subroutine precicef_is_coupling_ongoing(isOngoing) &
+      &  bind(c, name='precicef_is_coupling_ongoing_')
+
+      use, intrinsic :: iso_c_binding
+      integer(kind=c_int) :: isOngoing
+    end subroutine precicef_is_coupling_ongoing
     
+    ! Deprecated - Forwards to precicef_is_read_data_available_
     subroutine precicef_read_data_available(isAvailable) &
-      &  bind(c, name='precicef_read_data_available_')
+      &  bind(c, name='precicef_is_read_data_available_')
 
       use, intrinsic :: iso_c_binding
       integer(kind=c_int) :: isAvailable
     end subroutine precicef_read_data_available
 
+    subroutine precicef_is_read_data_available(isAvailable) &
+      &  bind(c, name='precicef_is_read_data_available_')
+
+      use, intrinsic :: iso_c_binding
+      integer(kind=c_int) :: isAvailable
+    end subroutine precicef_is_read_data_available
+
+    ! Deprecated - Forwards to precicef_is_write_data_required_
     subroutine precicef_write_data_required(computedTimestepLength, &
       &                                     isRequired) &
-      &  bind(c, name='precicef_write_data_required_')
+      &  bind(c, name='precicef_is_write_data_required_')
 
       use, intrinsic :: iso_c_binding
       real(kind=c_double) :: computedTimestepLength
       integer(kind=c_int) :: isRequired
     end subroutine precicef_write_data_required
+
+    subroutine precicef_is_write_data_required(computedTimestepLength, &
+      &                                       isRequired) &
+      &  bind(c, name='precicef_is_write_data_required_')
+
+      use, intrinsic :: iso_c_binding
+      real(kind=c_double) :: computedTimestepLength
+      integer(kind=c_int) :: isRequired
+    end subroutine precicef_is_write_data_required
 
     subroutine precicef_is_time_window_complete(isComplete) &
       &  bind(c, name='precicef_is_time_window_complete_')
@@ -94,8 +120,18 @@ module precice
       integer(kind=c_int) :: hasToEvaluate
     end subroutine precicef_has_to_evaluate_fine_model        
 
+    subroutine precicef_is_action_required(action, isRequired, lengthAction) &
+      &  bind(c, name='precicef_is_action_required_')
+
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: action
+      integer(kind=c_int)                  :: isRequired
+      integer(kind=c_int), value           :: lengthAction
+    end subroutine precicef_is_action_required
+
+    ! Deprecated - Forwards to precicef_is_action_required_
     subroutine precicef_action_required(action, isRequired, lengthAction) &
-      &  bind(c, name='precicef_action_required_')
+      &  bind(c, name='precicef_is_action_required_')
 
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: action


### PR DESCRIPTION
Renamed:
- precicef_ongoing: precicef_is_coupling_ongoing
- precicef_action_required: precicef_is_action_required
- precicef_read_data_available: precicef_is_read_data_available
- precicef_write_data_required: precicef_is_write_data_required

The old functions are now deprecated and will be removed with preCICE v3.

For consistency with the Fortran bindings and the C++ API.

Related to https://github.com/precice/precice/pull/815.
Closes #3.