### PR TITLE
Update link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fortran module for preCICE
 
-This is a Fortran module that uses the [preCICE Fortran bindings](https://github.com/precice/precice/wiki/Non%E2%80%93standard-APIs) (written in C++) using the `iso_c_binding` intrinsic module.
+This is a Fortran module that uses the [preCICE Fortran bindings](https://precice.org/couple-your-code-api.html) (written in C++) using the `iso_c_binding` intrinsic module.
 
 Build this module using `make`. This executes:
 ```bash


### PR DESCRIPTION
This replaces the link to the preCICE wiki on GitHub by the corresponding link to the preCICE homepage.