### PR TITLE
Add precicef_set_tetrahedron

### DIFF
--- a/precice.f03
+++ b/precice.f03
@@ -233,6 +233,18 @@ module precice
       integer(kind=c_int) :: secondEdgeID
       integer(kind=c_int) :: thirdEdgeID
     end subroutine precicef_set_triangle
+
+    subroutine precicef_set_tetrahedron(meshID, firstVertexID, secondVertexID, &
+      &                                 thirdVertexID, fourthVertexID) &
+      &  bind(c, name='precicef_set_tetrahedron')
+
+      use, intrinsic :: iso_c_binding
+      integer(kind=c_int) :: meshID
+      integer(kind=c_int) :: firstVertexID
+      integer(kind=c_int) :: secondVertexID
+      integer(kind=c_int) :: thirdVertexID
+      integer(kind=c_int) :: fourthVertexID
+    end subroutine precicef_set_tetrahedron
     
     subroutine precicef_set_triangle_we(meshID, firstVertexID, secondVertexID, &
       &                              thirdVertexID) &


### PR DESCRIPTION
Adds `precicef_set_tetrahedron`, implementing the same changes as https://github.com/precice/precice/commit/33c6e860eeae7b2d80afa90324fd5e2bd6c837cb#diff-448bd8c8b2323fdb2adcf653500138e5b2d398d047e960f06379eed2cd8f3ef1.

I have not tested it further than building.

