### PR TITLE
Port to preCICE v3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This is a Fortran module that uses the [preCICE Fortran bindings](https://precice.org/couple-your-code-api.html) (written in C++) using the `iso_c_binding` intrinsic module.
 
 Build this module using `make`. This executes:
-```bash
+
+```shell
 gfortran -c precice.f03
 ```
 

--- a/examples/solverdummy/Makefile
+++ b/examples/solverdummy/Makefile
@@ -3,7 +3,7 @@ F03 ?= gfortran
 all: solverdummy
 
 solverdummy: solverdummy.f03
-	$(F03) $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
+	$(F03) -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
 
 clean:
 	rm -f solverdummy

--- a/examples/solverdummy/README.md
+++ b/examples/solverdummy/README.md
@@ -6,18 +6,20 @@ To build this project, make sure you have already build `precice.mod`.
 Then simply run `make`.
 
 Alternatively, build this solver including `precice.mod` and linking to the preCICE library:
-```
+
+```shell
 gfortran solverdummy.f03 -I../.. -L$(pkg-config --libs libprecice)
 ```
+
 Where `../..` is the path to `precice.mod`.
 
 # Run
 
 You can test the dummy solver by coupling two instances with each other. Open two terminals and run
- * `./solverdummy precice-config.xml SolverOne MeshOne`
- * `./solverdummy precice-config.xml SolverTwo MeshTwo`
+
+ * `./solverdummy precice-config.xml SolverOne`
+ * `./solverdummy precice-config.xml SolverTwo`
 
 # Next Steps
 
 If you want to couple any other solver against the dummy be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).
- 

--- a/examples/solverdummy/precice-config.xml
+++ b/examples/solverdummy/precice-config.xml
@@ -1,52 +1,59 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-
   <log>
-    <sink type="stream" output="stdout"  filter= "%Severity% > debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true" />
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
   </log>
 
-  <solver-interface dimensions="3" >
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
 
-    <data:vector name="dataOne"  />
-    <data:vector name="dataTwo"  />
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
 
-    <mesh name="MeshOne">
-      <use-data name="dataOne" />
-      <use-data name="dataTwo" />
-    </mesh>
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
 
-    <mesh name="MeshTwo">
-      <use-data name="dataOne" />
-      <use-data name="dataTwo" />
-    </mesh>
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
 
-    <participant name="SolverOne">
-      <use-mesh name="MeshOne" provide="yes"/>
-      <write-data name="dataOne" mesh="MeshOne" />
-      <read-data  name="dataTwo" mesh="MeshOne" />
-    </participant>
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
 
-    <participant name="SolverTwo">
-      <use-mesh name="MeshOne" from="SolverOne"/>
-      <use-mesh name="MeshTwo" provide="yes"/>
-      <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative"/>
-      <mapping:nearest-neighbor direction="read"  from="MeshOne" to="MeshTwo" constraint="consistent" />
-      <write-data name="dataTwo" mesh="MeshTwo" />
-      <read-data  name="dataOne" mesh="MeshTwo" />
-    </participant>
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
-    <m2n:sockets from="SolverOne" to="SolverTwo"/>
-
-    <coupling-scheme:serial-implicit>
-      <participants first="SolverOne" second="SolverTwo" />
-      <max-time-windows value="2" />
-      <time-window-size value="1.0" />
-      <max-iterations value="2" />
-      <min-iteration-convergence-measure min-iterations="5" data="dataOne" mesh="MeshOne"/>
-      <exchange data="dataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-      <exchange data="dataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne"/>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
-
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <min-iterations value="2" />
+    <max-iterations value="2" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/examples/solverdummy/solverdummy.f03
+++ b/examples/solverdummy/solverdummy.f03
@@ -13,19 +13,19 @@ PROGRAM main
   INTEGER, DIMENSION(:), ALLOCATABLE :: vertexIDs
   integer(kind=c_int)             :: c_participantNameLength = 50
   integer(kind=c_int)             :: c_configFileNameLength = 50
-  integer(kind=c_int)             :: c_meshNameLength = 50
-  integer(kind=c_int)             :: c_dataNameLength = 50
 
   WRITE (*,*) 'DUMMY: Starting Fortran solver dummy...'
   CALL getarg(1, config)
   CALL getarg(2, participantName)
 
   IF(participantName .eq. 'SolverOne') THEN
+    write(*,*) "SolverOne"
     writeDataName = 'Data-One'
     readDataName = 'Data-Two'
     meshName = 'SolverOne-Mesh'
   ENDIF
   IF(participantName .eq. 'SolverTwo') THEN
+    write(*,*) "SolverTwo"
     writeDataName = 'Data-Two'
     readDataName = 'Data-One'
     meshName = 'SolverTwo-Mesh'
@@ -35,10 +35,10 @@ PROGRAM main
   commsize = 1
   dt = 1
   numberOfVertices = 3
-  CALL precicef_create(participantName, config, rank, commsize, c_participantNameLength, c_configFileNameLength)
+  CALL precicef_create(participantName, config, rank, commsize, 50, 50)
 
   ! Allocate dummy mesh with only one vertex
-  CALL precicef_get_mesh_dimensions(meshName, dimensions, c_meshNameLength)
+  CALL precicef_get_mesh_dimensions(meshName, dimensions, 50)
   ALLOCATE(vertices(numberOfVertices*dimensions))
   ALLOCATE(vertexIDs(numberOfVertices))
   ALLOCATE(readData(numberOfVertices*dimensions))
@@ -53,7 +53,7 @@ PROGRAM main
     vertexIDs(i) = i-1
   enddo
 
-  CALL precicef_set_vertices(meshName, numberOfVertices, vertices, vertexIDs, c_meshNameLength)
+  CALL precicef_set_vertices(meshName, numberOfVertices, vertices, vertexIDs, 50)
   DEALLOCATE(vertices)
 
   CALL precicef_requires_initial_data(bool)
@@ -72,15 +72,13 @@ PROGRAM main
     ENDIF
 
     CALL precicef_get_max_time_step_size(dt)
-    CALL precicef_read_data(meshName, readDataName, numberOfVertices, vertexIDs, dt, readData, &
-      &                     c_meshNameLength, c_dataNameLength)
+    CALL precicef_read_data(meshName, readDataName, numberOfVertices, vertexIDs, dt, readData, 50, 50)
 
     WRITE (*,*) 'readData: ', readData
 
     writeData = readData + 1
 
-    CALL precicef_write_data(meshName, writeDataName, numberOfVertices, vertexIDs, writeData, &
-      &                      c_meshNameLength, c_dataNameLength)
+    CALL precicef_write_data(meshName, writeDataName, numberOfVertices, vertexIDs, writeData, 50, 50)
 
     CALL precicef_advance(dt)
 

--- a/examples/solverdummy/solverdummy.f03
+++ b/examples/solverdummy/solverdummy.f03
@@ -4,52 +4,45 @@ PROGRAM main
   
   ! We need the length of the strings, set this to a meaningful value in your code.
   ! Here assumed that length = 50 (arbitrary).
-  CHARACTER*50                    :: config, participantName, meshName, writeInitialData, readItCheckp, writeItCheckp
+  CHARACTER*50                    :: config
+  CHARACTER*50                    :: participantName, meshName
   CHARACTER*50                    :: readDataName, writeDataName
-  INTEGER                         :: rank, commsize, ongoing, dimensions, meshID, bool, numberOfVertices, i,j
-  INTEGER                         :: readDataID, writeDataID
+  INTEGER                         :: rank, commsize, ongoing, dimensions, bool, numberOfVertices, i, j
   REAL(8)                         :: dt
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: vertices, writeData, readData
   INTEGER, DIMENSION(:), ALLOCATABLE :: vertexIDs
-  integer(kind=c_int)             :: c_accessorNameLength
-  integer(kind=c_int)             :: c_configFileNameLength
-
-  ! Constants in f90 have to be prefilled with blanks to be compatible with preCICE
-  writeInitialData(1:50)='                                                  '
-  readItCheckp(1:50)='                                                  '
-  writeItCheckp(1:50)='                                                  '
-  
-  CALL precicef_action_write_initial_data(writeInitialData, 50)
-  CALL precicef_action_read_iter_checkp(readItCheckp, 50)
-  CALL precicef_action_write_iter_checkp(writeItCheckp, 50)
+  integer(kind=c_int)             :: c_participantNameLength = 50
+  integer(kind=c_int)             :: c_configFileNameLength = 50
+  integer(kind=c_int)             :: c_meshNameLength = 50
+  integer(kind=c_int)             :: c_dataNameLength = 50
 
   WRITE (*,*) 'DUMMY: Starting Fortran solver dummy...'
   CALL getarg(1, config)
   CALL getarg(2, participantName)
-  CALL getarg(3, meshName)
 
   IF(participantName .eq. 'SolverOne') THEN
-    writeDataName = 'dataOne'
-    readDataName = 'dataTwo'
+    writeDataName = 'Data-One'
+    readDataName = 'Data-Two'
+    meshName = 'SolverOne-Mesh'
   ENDIF
   IF(participantName .eq. 'SolverTwo') THEN
-    writeDataName = 'dataTwo'
-    readDataName = 'dataOne'
+    writeDataName = 'Data-Two'
+    readDataName = 'Data-One'
+    meshName = 'SolverTwo-Mesh'
   ENDIF
 
   rank = 0
   commsize = 1
   dt = 1
   numberOfVertices = 3
-  CALL precicef_create(participantName, config, rank, commsize, 50, 50)
+  CALL precicef_create(participantName, config, rank, commsize, c_participantNameLength, c_configFileNameLength)
 
   ! Allocate dummy mesh with only one vertex
-  CALL precicef_get_dims(dimensions)
+  CALL precicef_get_mesh_dimensions(meshName, dimensions, c_meshNameLength)
   ALLOCATE(vertices(numberOfVertices*dimensions))
   ALLOCATE(vertexIDs(numberOfVertices))
   ALLOCATE(readData(numberOfVertices*dimensions))
   ALLOCATE(writeData(numberOfVertices*dimensions))
-  CALL precicef_get_mesh_id(meshName, meshID, 50)
 
   do i = 1,numberOfVertices,1
     do j = 1,dimensions,1
@@ -60,47 +53,40 @@ PROGRAM main
     vertexIDs(i) = i-1
   enddo
 
-  CALL precicef_set_vertices(meshID, numberOfVertices, vertices, vertexIDs)
+  CALL precicef_set_vertices(meshName, numberOfVertices, vertices, vertexIDs, c_meshNameLength)
   DEALLOCATE(vertices)
 
-  CALL precicef_get_data_id(readDataName,meshID,readDataID, 50)
-  CALL precicef_get_data_id(writeDataName,meshID,writeDataID, 50)
-
-  CALL precicef_initialize(dt)
-
-  CALL precicef_is_action_required(writeInitialData, bool, 50)
+  CALL precicef_requires_initial_data(bool)
   IF (bool.EQ.1) THEN
     WRITE (*,*) 'DUMMY: Writing initial data'
   ENDIF
-  CALL precicef_initialize_data()
+  CALL precicef_initialize()
 
   CALL precicef_is_coupling_ongoing(ongoing)
   DO WHILE (ongoing.NE.0)
 
-    CALL precicef_is_action_required(writeItCheckp, bool, 50)
+    CALL precicef_requires_writing_checkpoint(bool)
+
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Writing iteration checkpoint'
-      CALL precicef_mark_action_fulfilled(writeItCheckp, 50)
     ENDIF
 
-    CALL precicef_is_read_data_available(bool)
-    IF (bool.EQ.1) THEN
-      CALL precicef_read_bvdata(readDataID, numberOfVertices, vertexIDs, readData)
-    ENDIF
+    CALL precicef_get_max_time_step_size(dt)
+    CALL precicef_read_data(meshName, readDataName, numberOfVertices, vertexIDs, dt, readData, &
+      &                     c_meshNameLength, c_dataNameLength)
+
+    WRITE (*,*) 'readData: ', readData
 
     writeData = readData + 1
 
-    CALL precicef_is_write_data_required(dt, bool)
-    IF (bool.EQ.1) THEN
-      CALL precicef_write_bvdata(writeDataID, numberOfVertices, vertexIDs, writeData)
-    ENDIF
+    CALL precicef_write_data(meshName, writeDataName, numberOfVertices, vertexIDs, writeData, &
+      &                      c_meshNameLength, c_dataNameLength)
 
     CALL precicef_advance(dt)
 
-    CALL precicef_is_action_required(readItCheckp, bool, 50)
+    CALL precicef_requires_reading_checkpoint(bool)
     IF (bool.EQ.1) THEN
       WRITE (*,*) 'DUMMY: Reading iteration checkpoint'
-      CALL precicef_mark_action_fulfilled(readItCheckp, 50)
     ELSE
       WRITE (*,*) 'DUMMY: Advancing in time'
     ENDIF

--- a/precice.f03
+++ b/precice.f03
@@ -6,7 +6,7 @@ module precice
   
     subroutine precicef_create(participantName, configFileName, &
       &                        solverProcessIndex, solverProcessSize, &
-      &                        lengthAccessorName, lengthConfigFileName) &
+      &                        participantNameLength, configFileNameLength) &
       &  bind(c, name='precicef_create_')
 
       use, intrinsic :: iso_c_binding
@@ -14,22 +14,15 @@ module precice
       character(kind=c_char), dimension(*) :: configFileName
       integer(kind=c_int) :: solverProcessIndex
       integer(kind=c_int) :: solverProcessSize
-      integer(kind=c_int), value :: lengthAccessorName
-      integer(kind=c_int), value :: lengthConfigFileName
+      integer(kind=c_int), value :: participantNameLength
+      integer(kind=c_int), value :: configFileNameLength
     end subroutine precicef_create
 
-    subroutine precicef_initialize(timestepLengthLimit) &
+    subroutine precicef_initialize() &
       &  bind(c, name='precicef_initialize_')
 
       use, intrinsic :: iso_c_binding
-      real(kind=c_double) :: timestepLengthLimit
     end subroutine precicef_initialize
-    
-    subroutine precicef_initialize_data() &
-      &  bind(c, name='precicef_initialize_data_')
-
-      use, intrinsic :: iso_c_binding
-    end subroutine precicef_initialize_data
 
     subroutine precicef_advance(timestepLengthLimit) &
       &  bind(c, name='precicef_advance_')
@@ -38,25 +31,47 @@ module precice
       real(kind=c_double) :: timestepLengthLimit
     end subroutine precicef_advance
 
-    subroutine precicef_finalize() bind(c, name='precicef_finalize_')
+    subroutine precicef_finalize() &
+      & bind(c, name='precicef_finalize_')
 
       use, intrinsic :: iso_c_binding
     end subroutine precicef_finalize
 
-    subroutine precicef_get_dims(dimensions) &
-      &  bind(c, name='precicef_get_dims_')
+    subroutine precicef_requires_reading_checkpoint(isRequired) &
+       &  bind(c, name='precicef_requires_reading_checkpoint_')
+
+       use, intrinsic :: iso_c_binding
+       integer(kind=c_int) :: isRequired
+    end subroutine precicef_requires_reading_checkpoint
+
+    subroutine precicef_requires_writing_checkpoint(isRequired) &
+       &  bind(c, name='precicef_requires_writing_checkpoint_')
+
+       use, intrinsic :: iso_c_binding
+       integer(kind=c_int) :: isRequired
+    end subroutine precicef_requires_writing_checkpoint
+
+    subroutine precicef_get_mesh_dimensions(meshName, dimensions, &
+      & meshNameLength) &
+      & bind(c, name='precicef_get_mesh_dimensions_')
 
       use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: dimensions
-    end subroutine precicef_get_dims
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_get_mesh_dimensions
 
-    ! Deprecated - Forwards to precicef_is_coupling_ongoing_
-    subroutine precicef_ongoing(isOngoing) &
-      &  bind(c, name='precicef_is_coupling_ongoing_')
+    subroutine precicef_get_data_dimensions(meshName, dataName, &
+      & dimensions, meshNameLength, dataNameLength) &
+      & bind(c, name='precicef_get_data_dimensions_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: isOngoing
-    end subroutine precicef_ongoing
+      character(kind=c_char), dimension(*) :: meshName
+      character(kind=c_char), dimension(*) :: dataName
+      integer(kind=c_int) :: dimensions
+      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int) :: dataNameLength
+    end subroutine precicef_get_data_dimensions
 
     subroutine precicef_is_coupling_ongoing(isOngoing) &
       &  bind(c, name='precicef_is_coupling_ongoing_')
@@ -64,431 +79,235 @@ module precice
       use, intrinsic :: iso_c_binding
       integer(kind=c_int) :: isOngoing
     end subroutine precicef_is_coupling_ongoing
-    
-    ! Deprecated - Forwards to precicef_is_read_data_available_
-    subroutine precicef_read_data_available(isAvailable) &
-      &  bind(c, name='precicef_is_read_data_available_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: isAvailable
-    end subroutine precicef_read_data_available
-
-    subroutine precicef_is_read_data_available(isAvailable) &
-      &  bind(c, name='precicef_is_read_data_available_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: isAvailable
-    end subroutine precicef_is_read_data_available
-
-    ! Deprecated - Forwards to precicef_is_write_data_required_
-    subroutine precicef_write_data_required(computedTimestepLength, &
-      &                                     isRequired) &
-      &  bind(c, name='precicef_is_write_data_required_')
-
-      use, intrinsic :: iso_c_binding
-      real(kind=c_double) :: computedTimestepLength
-      integer(kind=c_int) :: isRequired
-    end subroutine precicef_write_data_required
-
-    subroutine precicef_is_write_data_required(computedTimestepLength, &
-      &                                       isRequired) &
-      &  bind(c, name='precicef_is_write_data_required_')
-
-      use, intrinsic :: iso_c_binding
-      real(kind=c_double) :: computedTimestepLength
-      integer(kind=c_int) :: isRequired
-    end subroutine precicef_is_write_data_required
 
     subroutine precicef_is_time_window_complete(isComplete) &
       &  bind(c, name='precicef_is_time_window_complete_')
 
       use, intrinsic :: iso_c_binding
       integer(kind=c_int) :: isComplete
-  end subroutine precicef_is_time_window_complete
+    end subroutine precicef_is_time_window_complete     
     
-    subroutine precicef_has_to_evaluate_surrogate_model(hasToEvaluate) &
-      &  bind(c, name='precicef_has_to_evaluate_surrogate_model_')
+    subroutine precicef_get_max_time_step_size(maxTimeStepSize) &
+      & bind(c, name='precicef_get_max_time_step_size_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: hasToEvaluate
-    end subroutine precicef_has_to_evaluate_surrogate_model
-    
-    subroutine precicef_has_to_evaluate_fine_model(hasToEvaluate) &
-      &  bind(c, name='precicef_has_to_evaluate_fine_model_')
+      real(kind=c_double) :: maxTimeStepSize
+    end subroutine precicef_get_max_time_step_size
 
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: hasToEvaluate
-    end subroutine precicef_has_to_evaluate_fine_model        
-
-    subroutine precicef_is_action_required(action, isRequired, lengthAction) &
-      &  bind(c, name='precicef_is_action_required_')
-
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: action
-      integer(kind=c_int)                  :: isRequired
-      integer(kind=c_int), value           :: lengthAction
-    end subroutine precicef_is_action_required
-
-    ! Deprecated - Forwards to precicef_is_action_required_
-    subroutine precicef_action_required(action, isRequired, lengthAction) &
-      &  bind(c, name='precicef_is_action_required_')
-
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: action
-      integer(kind=c_int)                  :: isRequired
-      integer(kind=c_int), value           :: lengthAction
-    end subroutine precicef_action_required
-
-    subroutine precicef_mark_action_fulfilled(action, lengthAction) &
-      &  bind(c, name='precicef_mark_action_fulfilled_')
-
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: action
-      integer(kind=c_int), value           :: lengthAction
-    end subroutine precicef_mark_action_fulfilled
-
-    subroutine precicef_has_mesh(meshName, hasMesh, lengthMeshName) &
-      &  bind(c, name='precicef_has_mesh_')
+    subroutine precicef_requires_mesh_connectivity_for(meshName, required, meshNameLength) &
+      & bind(c, name='precicef_requires_mesh_connectivity_for_')
 
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
-      integer(kind=c_int)                  :: hasMesh
-      integer(kind=c_int), value           :: lengthMeshName
-    end subroutine precicef_has_mesh  
+      integer(kind=c_int) :: required
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_requires_mesh_connectivity_for
 
-    subroutine precicef_get_mesh_id(meshName, meshID, lengthMeshName) &
-      &  bind(c, name='precicef_get_mesh_id_')
-
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: meshName
-      integer(kind=c_int)                  :: meshID
-      integer(kind=c_int), value           :: lengthMeshName
-    end subroutine precicef_get_mesh_id
-
-    subroutine precicef_set_vertex(meshID, position, vertexID) &
+    subroutine precicef_set_vertex(meshName, position, vertexID) &
       &  bind(c, name='precicef_set_vertex_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      real(kind=c_double) :: position(3)
-      integer(kind=c_int) :: vertexID
+      character(kind=c_char), dimension(*) :: meshName
+      real(kind=c_double) :: coordinates(3)
+      integer(kind=c_int) :: id
     end subroutine precicef_set_vertex
     
-    subroutine precicef_get_mesh_vertex_size(meshID, meshSize) &
+    subroutine precicef_get_mesh_vertex_size(meshName, meshSize, meshNameLength) &
       &  bind(c, name='precicef_get_mesh_vertex_size_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
+      character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: meshSize
+      integer(kind=c_int) :: meshNameLength
     end subroutine precicef_get_mesh_vertex_size    
     
-    subroutine precicef_set_vertices(meshID, meshsize, positions, positionIDs) &
+    subroutine precicef_set_vertices(meshName, size, coordinates, ids, meshNameLength) &
       &  bind(c, name='precicef_set_vertices_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      integer(kind=c_int) :: meshsize
-      real(kind=c_double) :: positions(*)
-      integer(kind=c_int) :: positionIDs(*)
-    end subroutine precicef_set_vertices
-    
-    subroutine precicef_get_vertices(meshID, size, ids, positions ) &
-      &  bind(c, name='precicef_get_vertices_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
+      character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: size
+      real(kind=c_double) :: coordinates(*)
       integer(kind=c_int) :: ids(*)
-      real(kind=c_double) :: positions(*)
-    end subroutine precicef_get_vertices    
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_vertices 
 
-    subroutine precicef_get_vertex_ids_from_positions(meshID, size, positions, ids ) &
-      &  bind(c, name='precicef_get_vertices_from_positions_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      integer(kind=c_int) :: size
-      real(kind=c_double) :: positions(*)
-      integer(kind=c_int) :: ids(*)
-    end subroutine precicef_get_vertex_ids_from_positions   
-
-    subroutine precicef_set_edge(meshID, firstVertexID, secondVertexID, &
-      &                          edgeID) &
+    subroutine precicef_set_edge(meshName, firstVertexID, secondVertexID, &
+      &                          meshNameLength) &
       &  bind(c, name='precicef_set_edge_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
+      character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: firstVertexID
       integer(kind=c_int) :: secondVertexID
-      integer(kind=c_int) :: edgeID
+      integer(kind=c_int) :: meshNameLength
     end subroutine precicef_set_edge
 
-    subroutine precicef_set_triangle(meshID, firstEdgeID, secondEdgeID, &
-      &                              thirdEdgeID) &
+    subroutine precicef_set_mesh_edges(meshName, size, ids, meshNameLength) &
+      & bind(c, name='precicef_set_mesh_edges_')
+    
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_mesh_edges
+
+    subroutine precicef_set_triangle(meshName, firstEdgeID, secondEdgeID, &
+      &                              thirdEdgeID, meshNameLength) &
       &  bind(c, name='precicef_set_triangle_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
+      character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: firstEdgeID
       integer(kind=c_int) :: secondEdgeID
       integer(kind=c_int) :: thirdEdgeID
+      integer(kind=c_int) :: meshNameLength
     end subroutine precicef_set_triangle
 
-    subroutine precicef_set_tetrahedron(meshID, firstVertexID, secondVertexID, &
-      &                                 thirdVertexID, fourthVertexID) &
-      &  bind(c, name='precicef_set_tetrahedron')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      integer(kind=c_int) :: firstVertexID
-      integer(kind=c_int) :: secondVertexID
-      integer(kind=c_int) :: thirdVertexID
-      integer(kind=c_int) :: fourthVertexID
-    end subroutine precicef_set_tetrahedron
-    
-    subroutine precicef_set_triangle_we(meshID, firstVertexID, secondVertexID, &
-      &                              thirdVertexID) &
-      &  bind(c, name='precicef_set_triangle_we_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      integer(kind=c_int) :: firstVertexID
-      integer(kind=c_int) :: secondVertexID
-      integer(kind=c_int) :: thirdVertexID
-    end subroutine precicef_set_triangle_we
-
-    subroutine precicef_set_quad(meshID, firstEdgeID, secondEdgeID, &
-      &                              thirdEdgeID, fourthEdgeID ) &
+    subroutine precicef_set_quad(meshName, firstVertexID, secondVertexID, &
+      &                          thirdVertexID, fourthVertexID, &
+      &                          meshNameLength ) &
       &  bind(c, name='precicef_set_quad_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      integer(kind=c_int) :: firstEdgeID
-      integer(kind=c_int) :: secondEdgeID
-      integer(kind=c_int) :: thirdEdgeID
-      integer(kind=c_int) :: fourthEdgeID
-    end subroutine precicef_set_quad
-    
-    subroutine precicef_set_quad_we(meshID, firstVertexID, secondVertexID, &
-      &                              thirdVertexID, fourthVertexID) &
-      &  bind(c, name='precicef_set_quad_we_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
+      character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: firstVertexID
       integer(kind=c_int) :: secondVertexID
       integer(kind=c_int) :: thirdVertexID
       integer(kind=c_int) :: fourthVertexID
-    end subroutine precicef_set_quad_we    
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_quad
 
-   subroutine precicef_has_data(dataName, meshID, hasData, lengthDataName) &
-      &  bind(c, name='precicef_has_data_')
+    subroutine precicef_set_mesh_quads(meshName, size, ids, meshNameLength) &
+      & bind(c, name='precicef_set_mesh_quads_')
+    
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_mesh_quads
+
+    subroutine precicef_set_tetrahedron(meshName, firstVertexID, secondVertexID, &
+      &                                 thirdVertexID, fourthVertexID, &
+      &                                 meshNameLength) &
+      &  bind(c, name='precicef_set_tetrahedron')
 
       use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
+      integer(kind=c_int) :: firstVertexID
+      integer(kind=c_int) :: secondVertexID
+      integer(kind=c_int) :: thirdVertexID
+      integer(kind=c_int) :: fourthVertexID
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_tetrahedron
+  
+    subroutine precicef_set_mesh_tetrahedra(meshName, size, ids, meshNameLength) &
+      & bind(c, name='precicef_set_mesh_tetrahedra_')
+    
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_mesh_tetrahedra
+
+    subroutine precicef_requires_initial_data(isRequired) &
+      & bind(c, name='precicef_requires_initial_data_')
+    
+      use, intrinsic :: iso_c_binding
+      integer(kind=c_int) :: isRequired
+    end subroutine precicef_requires_initial_data
+
+    subroutine precicef_write_data(meshName, dataName, size, ids, &
+      &                            values, meshNameLength, dataNameLength) &
+      & bind(c, name='precicef_write_data_')
+    
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
       character(kind=c_char), dimension(*) :: dataName
-      integer(kind=c_int)                  :: meshID
-      integer(kind=c_int)                  :: hasData
-      integer(kind=c_int), value           :: lengthDataName
-    end subroutine precicef_has_data
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      real(kind=c_double) :: values(*)
+      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int) :: dataNameLength
+    end subroutine precicef_write_data
 
-    subroutine precicef_get_data_id(dataName, meshID, dataID, lengthDataName ) &
-      &  bind(c, name='precicef_get_data_id_')
-
+    subroutine precicef_read_data(meshName, dataName, size, ids, &
+      &                           relativeReadTime, values, meshNameLength, &
+      &                           dataNameLength) &
+      & bind(c, name='precicef_read_data_')
+    
       use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
       character(kind=c_char), dimension(*) :: dataName
-      integer(kind=c_int)                  :: meshID
-      integer(kind=c_int)                  :: dataID
-      integer(kind=c_int), value           :: lengthDataName
-    end subroutine precicef_get_data_id
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      real(kind=c_double) :: relativeReadTime(*)
+      real(kind=c_double) :: values(*)
+      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int) :: dataNameLength
+    end subroutine precicef_read_data
 
-    subroutine precicef_is_mesh_connectivity_required(meshID, required) &
-      & bind(c, name='precicef_is_mesh_connectivity_required_')
+    subroutine precicef_set_mesh_access_region(meshName, boundingBox, &
+      &                                        meshNameLength) &
+      & bind(c, name='precicef_set_mesh_access_region_')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
+      character(kind=c_char), dimension(*) :: meshName
+      real(kind=c_double) :: boundingBox(*)
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_set_mesh_access_region
+
+    subroutine precicef_get_mesh_vertex_ids_and_coordinates(meshName, size, &
+      &                                                     ids, coordinates, &
+      &                                                     meshNameLength) &
+      & bind(c, name='precicef_get_mesh_vertex_ids_and_coordinates_')
+
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      real(kind=c_double) :: coordinates(*) 
+      integer(kind=c_int) :: meshNameLength
+    end subroutine precicef_get_mesh_vertex_ids_and_coordinates
+
+    subroutine precicef_requires_gradient_data_for(meshName, dataName, &
+      &                                            required, meshNameLength, &
+      &                                            dataNameLength) &
+      & bind(c, name='precicef_requires_gradient_data_for_')
+
+      use, intrinsic :: iso_c_binding
+      character(kind=c_char), dimension(*) :: meshName
+      character(kind=c_char), dimension(*) :: dataName
       integer(kind=c_int) :: required
-    end subroutine precicef_is_mesh_connectivity_required
+      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int) :: dataNameLength
+    end subroutine precicef_requires_gradient_data_for
 
-    subroutine precicef_map_read_data_to(meshID) &
-      &  bind(c, name='precicef_map_read_data_to_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-    end subroutine precicef_map_read_data_to
-    
-    subroutine precicef_map_write_data_from(meshID) &
-      &  bind(c, name='precicef_map_write_data_from_')
+    subroutine precicef_write_gradient_data(meshName, dataName, size, ids, &
+      &                                     gradients, meshNameLength, &
+      &                                     dataNameLength) &
+      & bind(c, name='precicef_write_gradient_data')
 
       use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-    end subroutine precicef_map_write_data_from
-
-    subroutine precicef_write_sdata( dataID, valueIndex, dataValue) &
-      &  bind(c, name='precicef_write_sdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: valueIndex
-      real(kind=c_double) :: dataValue   
-    end subroutine precicef_write_sdata
-
-    subroutine precicef_write_bsdata( dataID, blockSize, valueIndices, values) &
-      &  bind(c, name='precicef_write_bsdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: blockSize
-      integer(kind=c_int) :: valueIndices(*)
-      real(kind=c_double) :: values(*)   
-    end subroutine precicef_write_bsdata
-
-    subroutine precicef_write_vdata( dataID, valueIndex, dataValue) &
-      &  bind(c, name='precicef_write_vdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: valueIndex
-      real(kind=c_double), dimension(*) :: dataValue 
-    end subroutine precicef_write_vdata
-    
-    subroutine precicef_write_bvdata( dataID, blockSize, valueIndices, values) &
-      &  bind(c, name='precicef_write_bvdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: blockSize
-      integer(kind=c_int) :: valueIndices(*)
-      real(kind=c_double) :: values(*)   
-    end subroutine precicef_write_bvdata  
-    
-    subroutine precicef_read_sdata( dataID, valueIndex, dataValue) &
-      &  bind(c, name='precicef_read_sdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: valueIndex
-      real(kind=c_double) :: dataValue   
-    end subroutine precicef_read_sdata
-
-    subroutine precicef_read_bsdata( dataID, blocksize, valueIndices, values) &
-      &  bind(c, name='precicef_read_bsdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: blocksize
-      integer(kind=c_int) :: valueIndices(*)
-      real(kind=c_double) :: values(*)   
-    end subroutine precicef_read_bsdata
-
-    subroutine precicef_read_vdata( dataID, valueIndex, dataValue) &
-      &  bind(c, name='precicef_read_vdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: valueIndex
-      real(kind=c_double) :: dataValue(*)
-    end subroutine precicef_read_vdata
-    
-    subroutine precicef_read_bvdata( dataID, blocksize, valueIndices, values) &
-      &  bind(c, name='precicef_read_bvdata_')
-
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: blocksize
-      integer(kind=c_int) :: valueIndices(*)
-      real(kind=c_double) :: values(*)   
-    end subroutine precicef_read_bvdata
-
-    subroutine precicef_action_write_iter_checkp(nameAction, lengthNameAction) &
-      &        bind(c, name="precicef_action_write_iter_checkp_")
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: nameAction
-      integer(kind=c_int), value :: lengthNameAction
-    end subroutine precicef_action_write_iter_checkp
-
-    subroutine precicef_action_write_initial_data(nameAction, lengthNameAction) &
-      &        bind(c, name="precicef_action_write_initial_data_")
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: nameAction
-      integer(kind=c_int), value :: lengthNameAction
-    end subroutine precicef_action_write_initial_data
-
-    subroutine precicef_action_read_iter_checkp(nameAction, lengthNameAction) &
-      &        bind(c, name="precicef_action_read_iter_checkp_")
-      use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: nameAction
-      integer(kind=c_int), value :: lengthNameAction
-    end subroutine precicef_action_read_iter_checkp
+      character(kind=c_char), dimension(*) :: meshName
+      character(kind=c_char), dimension(*) :: dataName
+      integer(kind=c_int) :: size
+      integer(kind=c_int) :: ids(*)
+      real(kind=c_double) :: gradients(*)
+      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int) :: dataNameLength
+    end subroutine precicef_write_gradient_data
 
     subroutine precicef_get_version_information(versionInfo, lengthVersionInfo) &
       &        bind(c, name="precicef_get_version_information_")
+
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: versionInfo
       integer(kind=c_int), value :: lengthVersionInfo
     end subroutine precicef_get_version_information
-
-    ! Experimental API function
-    subroutine precicef_set_mesh_access_region(meshID, boundingBox) &
-      &        bind(c, name="precicef_set_mesh_access_region_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      real(kind=c_double) :: boundingBox(*)  
-    end subroutine precicef_set_mesh_access_region
-
-    ! Experimental API function
-    subroutine precicef_get_mesh_vertices_and_ids(meshID, size, ids, coordinates) &
-      &        bind(c, name="precicef_get_mesh_vertices_and_IDs_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: meshID
-      integer(kind=c_int) :: size
-      integer(kind=c_int) :: ids(*)
-      real(kind=c_double) :: coordinates(*) 
-    end subroutine precicef_get_mesh_vertices_and_ids
-
-    ! Gradient API functions
-    subroutine precicef_is_gradient_data_required(dataID, isRequired) &
-      &        bind(c, name="precicef_is_gradient_data_required_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: isRequired
-    end subroutine precicef_is_gradient_data_required
-
-    ! Gradient API functions 
-    subroutine precicef_write_sgradient_data(dataID, valueIndex, dataValue) &
-      &        bind(c, name="precicef_write_sgradient_data_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: valueIndex
-      real(kind=c_double) :: dataValue(*)
-    end subroutine precicef_write_sgradient_data
-    
-    ! Gradient API functions
-    subroutine precicef_write_bsgradient_data(dataID,size,valueIndices,gradientValues) &
-      &        bind(c, name="precicef_write_bsgradient_data_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: size
-      integer(kind=c_int) :: valueIndices(*)
-      real(kind=c_double) :: gradientValues(*)   
-    end subroutine precicef_write_bsgradient_data
-
-    ! Gradient API functions
-    subroutine precicef_write_vgradient_data(dataID, valueIndex, dataValue) &
-      &        bind(c, name="precicef_write_vgradient_data_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: valueIndex
-      real(kind=c_double) :: dataValue(*)
-    end subroutine precicef_write_vgradient_data
-
-    subroutine precicef_write_bvgradient_data(dataID, blocksize, valueIndices, gradientValues) &
-      &        bind(c, name="precicef_write_bvgradient_data_")
-      use, intrinsic :: iso_c_binding
-      integer(kind=c_int) :: dataID
-      integer(kind=c_int) :: blocksize
-      integer(kind=c_int) :: valueIndices(*)
-      real(kind=c_double) :: gradientValues(*)   
-    end subroutine precicef_write_bvgradient_data
 
   end interface
 

--- a/precice.f03
+++ b/precice.f03
@@ -58,7 +58,7 @@ module precice
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: dimensions
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_get_mesh_dimensions
 
     subroutine precicef_get_data_dimensions(meshName, dataName, &
@@ -69,8 +69,8 @@ module precice
       character(kind=c_char), dimension(*) :: meshName
       character(kind=c_char), dimension(*) :: dataName
       integer(kind=c_int) :: dimensions
-      integer(kind=c_int) :: meshNameLength
-      integer(kind=c_int) :: dataNameLength
+      integer(kind=c_int), value :: meshNameLength
+      integer(kind=c_int), value :: dataNameLength
     end subroutine precicef_get_data_dimensions
 
     subroutine precicef_is_coupling_ongoing(isOngoing) &
@@ -100,7 +100,7 @@ module precice
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: required
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_requires_mesh_connectivity_for
 
     subroutine precicef_set_vertex(meshName, position, vertexID) &
@@ -118,7 +118,7 @@ module precice
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: meshSize
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_get_mesh_vertex_size    
     
     subroutine precicef_set_vertices(meshName, size, coordinates, ids, meshNameLength) &
@@ -129,7 +129,7 @@ module precice
       integer(kind=c_int) :: size
       real(kind=c_double) :: coordinates(*)
       integer(kind=c_int) :: ids(*)
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_vertices 
 
     subroutine precicef_set_edge(meshName, firstVertexID, secondVertexID, &
@@ -140,7 +140,7 @@ module precice
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: firstVertexID
       integer(kind=c_int) :: secondVertexID
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_edge
 
     subroutine precicef_set_mesh_edges(meshName, size, ids, meshNameLength) &
@@ -150,7 +150,7 @@ module precice
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_mesh_edges
 
     subroutine precicef_set_triangle(meshName, firstEdgeID, secondEdgeID, &
@@ -162,7 +162,7 @@ module precice
       integer(kind=c_int) :: firstEdgeID
       integer(kind=c_int) :: secondEdgeID
       integer(kind=c_int) :: thirdEdgeID
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_triangle
 
     subroutine precicef_set_quad(meshName, firstVertexID, secondVertexID, &
@@ -176,7 +176,7 @@ module precice
       integer(kind=c_int) :: secondVertexID
       integer(kind=c_int) :: thirdVertexID
       integer(kind=c_int) :: fourthVertexID
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_quad
 
     subroutine precicef_set_mesh_quads(meshName, size, ids, meshNameLength) &
@@ -186,7 +186,7 @@ module precice
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_mesh_quads
 
     subroutine precicef_set_tetrahedron(meshName, firstVertexID, secondVertexID, &
@@ -200,7 +200,7 @@ module precice
       integer(kind=c_int) :: secondVertexID
       integer(kind=c_int) :: thirdVertexID
       integer(kind=c_int) :: fourthVertexID
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_tetrahedron
   
     subroutine precicef_set_mesh_tetrahedra(meshName, size, ids, meshNameLength) &
@@ -210,7 +210,7 @@ module precice
       character(kind=c_char), dimension(*) :: meshName
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_mesh_tetrahedra
 
     subroutine precicef_requires_initial_data(isRequired) &
@@ -230,8 +230,8 @@ module precice
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
       real(kind=c_double) :: values(*)
-      integer(kind=c_int) :: meshNameLength
-      integer(kind=c_int) :: dataNameLength
+      integer(kind=c_int), value :: meshNameLength
+      integer(kind=c_int), value :: dataNameLength
     end subroutine precicef_write_data
 
     subroutine precicef_read_data(meshName, dataName, size, ids, &
@@ -246,8 +246,8 @@ module precice
       integer(kind=c_int) :: ids(*)
       real(kind=c_double) :: relativeReadTime
       real(kind=c_double) :: values(*)
-      integer(kind=c_int) :: meshNameLength
-      integer(kind=c_int) :: dataNameLength
+      integer(kind=c_int), value :: meshNameLength
+      integer(kind=c_int), value :: dataNameLength
     end subroutine precicef_read_data
 
     subroutine precicef_set_mesh_access_region(meshName, boundingBox, &
@@ -257,7 +257,7 @@ module precice
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
       real(kind=c_double) :: boundingBox(*)
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_mesh_access_region
 
     subroutine precicef_get_mesh_vertex_ids_and_coordinates(meshName, size, &
@@ -270,7 +270,7 @@ module precice
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
       real(kind=c_double) :: coordinates(*) 
-      integer(kind=c_int) :: meshNameLength
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_get_mesh_vertex_ids_and_coordinates
 
     subroutine precicef_requires_gradient_data_for(meshName, dataName, &
@@ -282,8 +282,8 @@ module precice
       character(kind=c_char), dimension(*) :: meshName
       character(kind=c_char), dimension(*) :: dataName
       integer(kind=c_int) :: required
-      integer(kind=c_int) :: meshNameLength
-      integer(kind=c_int) :: dataNameLength
+      integer(kind=c_int), value :: meshNameLength
+      integer(kind=c_int), value :: dataNameLength
     end subroutine precicef_requires_gradient_data_for
 
     subroutine precicef_write_gradient_data(meshName, dataName, size, ids, &
@@ -297,8 +297,8 @@ module precice
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
       real(kind=c_double) :: gradients(*)
-      integer(kind=c_int) :: meshNameLength
-      integer(kind=c_int) :: dataNameLength
+      integer(kind=c_int), value :: meshNameLength
+      integer(kind=c_int), value :: dataNameLength
     end subroutine precicef_write_gradient_data
 
     subroutine precicef_get_version_information(versionInfo, lengthVersionInfo) &

--- a/precice.f03
+++ b/precice.f03
@@ -244,7 +244,7 @@ module precice
       character(kind=c_char), dimension(*) :: dataName
       integer(kind=c_int) :: size
       integer(kind=c_int) :: ids(*)
-      real(kind=c_double) :: relativeReadTime(*)
+      real(kind=c_double) :: relativeReadTime
       real(kind=c_double) :: values(*)
       integer(kind=c_int) :: meshNameLength
       integer(kind=c_int) :: dataNameLength

--- a/precice.f03
+++ b/precice.f03
@@ -103,13 +103,14 @@ module precice
       integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_requires_mesh_connectivity_for
 
-    subroutine precicef_set_vertex(meshName, position, vertexID) &
+    subroutine precicef_set_vertex(meshName, position, vertexID, meshNameLength) &
       &  bind(c, name='precicef_set_vertex_')
 
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
       real(kind=c_double) :: coordinates(3)
       integer(kind=c_int) :: id
+      integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_vertex
     
     subroutine precicef_get_mesh_vertex_size(meshName, meshSize, meshNameLength) &


### PR DESCRIPTION
Updates the Fortran module to preCICE v3 (https://github.com/precice/precice/pull/1914).

- [x] Port interface to v3 API
- [x] Port solverdummy code to v3 interface
- [x] Port solverdummy config to v3 interface
- [x] Debug

@fsimonis Please check in particular whether I have missed defining anything as an array (pointer).

I think there were already many ghosts in the interface file, and the fact that the interface is not checked for linking to preCICE does not make me feel very comfortable. Maybe there is a way to check that.