### PR TITLE
Require std=f2003 and update some legacy style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ F03 ?= gfortran
 all: precice
 
 precice: precice.f90
-	$(F03) -c $^
+	$(F03) -std=f2003 -c $^
 
 clean:
 	rm -f precice.mod precice.o

--- a/examples/solverdummy/Makefile
+++ b/examples/solverdummy/Makefile
@@ -3,7 +3,7 @@ F03 ?= gfortran
 all: solverdummy
 
 solverdummy: solverdummy.f90
-	$(F03) -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
+	$(F03)  -std=f2003 -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
 
 clean:
 	rm -f solverdummy

--- a/examples/solverdummy/solverdummy.f90
+++ b/examples/solverdummy/solverdummy.f90
@@ -4,9 +4,9 @@ PROGRAM main
   
   ! We need the length of the strings, set this to a meaningful value in your code.
   ! Here assumed that length = 50 (arbitrary).
-  CHARACTER*50                    :: config
-  CHARACTER*50                    :: participantName, meshName
-  CHARACTER*50                    :: readDataName, writeDataName
+  CHARACTER(50)                   :: config
+  CHARACTER(50)                   :: participantName, meshName
+  CHARACTER(50)                   :: readDataName, writeDataName
   INTEGER                         :: rank, commsize, ongoing, dimensions, bool, numberOfVertices, i, j
   REAL(8)                         :: dt
   DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: vertices, writeData, readData
@@ -15,8 +15,8 @@ PROGRAM main
   integer(kind=c_int)             :: c_configFileNameLength = 50
 
   WRITE (*,*) 'DUMMY: Starting Fortran solver dummy...'
-  CALL getarg(1, config)
-  CALL getarg(2, participantName)
+  CALL get_command_argument(1, config)
+  CALL get_command_argument(2, participantName)
 
   IF(participantName .eq. 'SolverOne') THEN
     write(*,*) "SolverOne"


### PR DESCRIPTION
- Adds `-std=f2003` to the Makefiles (they anyway assume gfortran, let's not address this here)
- Replaces `CHARACTER*50` declarations by `CHARACTER(50)`, as the `*50` is the legacy way and leads to warnings.
- Replaces calls to `getarg` by calls to `get_command_argument`, as the former is not available when I set `f2003`. Following the suggestion of the [getarg documentation](https://gcc.gnu.org/onlinedocs/gfortran/GETARG.html).

@ivan-pi any objections?

Closes #18