### PR TITLE
Add a pre-commit hook

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,0 +1,31 @@
+name: Check style and scripts
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  check_style:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+         python-version: '3.10'
+         check-latest: true
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run checks
+        run: pre-commit run -a -v
+      - name: Git status
+        if: always()
+        run: git status
+      - name: Full diff
+        if: always()
+        run: git diff

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "MD013": false,
+    "MD033": false,
+    "MD034": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+# Official repo for default hooks
+- repo: https://github.com/precice/precice-pre-commit-hooks
+  rev: 'v3.3'
+  hooks:
+  - id: format-precice-config
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.30.0
+  hooks:
+    - id: markdownlint
+      exclude: changelog-entries
+    - id: markdownlint-fix
+      exclude: changelog-entries
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.10.0
+  hooks:
+    - id: shellcheck
+      args: [ --external-sources, --exclude=SC1091 ]

--- a/examples/solverdummy/README.md
+++ b/examples/solverdummy/README.md
@@ -1,6 +1,8 @@
+# preCICE solverdummy in Fortran
+
 This is an example of a Fortran 2003 solver dummy.
 
-# Building
+## Building
 
 To build this project, make sure you have already build `precice.mod`.
 Then simply run `make`.
@@ -13,13 +15,13 @@ gfortran solverdummy.f90 -I../.. -L$(pkg-config --libs libprecice)
 
 Where `../..` is the path to `precice.mod`.
 
-# Run
+## Run
 
 You can test the dummy solver by coupling two instances with each other. Open two terminals and run
 
- * `./solverdummy precice-config.xml SolverOne`
- * `./solverdummy precice-config.xml SolverTwo`
+* `./solverdummy precice-config.xml SolverOne`
+* `./solverdummy precice-config.xml SolverTwo`
 
-# Next Steps
+## Next Steps
 
 If you want to couple any other solver against the dummy be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).


### PR DESCRIPTION
Covers:

- Formatting the precice-config.xml
- Checking the Markdown files
- Checking shell scripts with shellcheck

Based on the similar pre-commit hook already contributed to the tutorials repository by @fsimonis.

Partially addresses #23 (not for the Fortran formatting).