### PR TITLE
Make C prototypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Generated prototype for linking tests
+precice-prototype.h

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,8 @@ all: precice
 precice: precice.f90
 	$(F03) -c $^
 
+prototype: precice.f90
+	$(F03) -fc-prototypes -fsyntax-only $^ -I../.. $(shell pkg-config --libs libprecice) > precice-prototype.h
+
 clean:
-	rm -f precice.mod precice.o
+	rm -f precice.mod precice.o precice-prototype.h

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ F03 ?= gfortran
 all: precice
 
 precice: precice.f90
-	$(F03) -c $^
+	$(F03) -c -fimplicit-none $^
 
 prototype: precice.f90
-	$(F03) -fc-prototypes -fsyntax-only $^ -I../.. $(shell pkg-config --libs libprecice) > precice-prototype.h
+	$(F03) -fimplicit-none -fc-prototypes -fsyntax-only $^ -I../.. $(shell pkg-config --libs libprecice) > precice-prototype.h
 
 clean:
 	rm -f precice.mod precice.o precice-prototype.h

--- a/examples/solverdummy/Makefile
+++ b/examples/solverdummy/Makefile
@@ -3,7 +3,7 @@ F03 ?= gfortran
 all: solverdummy
 
 solverdummy: solverdummy.f90
-	$(F03) -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
+	$(F03) -fimplicit-none -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
 
 clean:
 	rm -f solverdummy

--- a/precice.f90
+++ b/precice.f90
@@ -103,7 +103,7 @@ module precice
       integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_requires_mesh_connectivity_for
 
-    subroutine precicef_set_vertex(meshName, position, vertexID, meshNameLength) &
+    subroutine precicef_set_vertex(meshName, coordinates, id, meshNameLength) &
       &  bind(c, name='precicef_set_vertex_')
 
       use, intrinsic :: iso_c_binding


### PR DESCRIPTION
With this PR, `make prototype` will generate a `precice-prototype.h` file. This includes warnings for non-interoperable types, as, for example:

```
void precicef_set_vertex_ (char *meshname, float *position /* WARNING: non-interoperable KIND */ , float *vertexid /* WARNING: non-interoperable KIND */ , int meshnamelength);
```

Not sure where the `float` comes from, I don't see it in any of the involved files:

- `precice.f90`
- `precice/precice/extras/bindings/fortran/`
- `precice/precice/extras/bindings/c/`

Applies https://fortran-lang.discourse.group/t/compilers-supporting-generation-of-c-function-prototypes/2688 suggested by @ivan-pi.

Not sure at the moment what would be the best way to use the generated prototype to detect inconsistencies. I need more time to investigate, which I currently do not have.

When complete, it should close #15.