### PR TITLE
API with and without null-terminated strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 FC ?= gfortran
+FFLAGS ?= -Wall
 
 all: precice
 
 precice: precice.f90
-	$(FC) -std=f2003 -c $^
+	$(FC) $(FFLAGS) -c $^
 
 clean:
 	rm -f precice.mod precice.o

--- a/examples/solverdummy/.gitignore
+++ b/examples/solverdummy/.gitignore
@@ -1,0 +1,4 @@
+solverdummy
+*.log
+precice-profiling/
+precice-run/

--- a/examples/solverdummy/Makefile
+++ b/examples/solverdummy/Makefile
@@ -1,9 +1,10 @@
 FC ?= gfortran
+FFLAGS ?= -Wall
 
 all: solverdummy
 
 solverdummy: solverdummy.f90
-	$(FC)  -std=f2003 -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
+	$(FC) $(FFLAGS) -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
 
 clean:
 	rm -f solverdummy

--- a/examples/solverdummy/solverdummy.f90
+++ b/examples/solverdummy/solverdummy.f90
@@ -35,7 +35,7 @@ PROGRAM main
   commsize = 1
   dt = 1
   numberOfVertices = 3
-  CALL precicef_create(participantName, config, rank, commsize, 50, 50)
+  CALL precicef_create(participantName, config, rank, commsize)
 
   ! Allocate dummy mesh with only one vertex
   CALL precicef_get_mesh_dimensions(meshName, dimensions, 50)

--- a/examples/solverdummy/solverdummy.f90
+++ b/examples/solverdummy/solverdummy.f90
@@ -29,7 +29,7 @@ PROGRAM main
     readDataName = 'Data-One'
     meshName = 'SolverTwo-Mesh'
   CASE DEFAULT
-    ERROR STOP "The provided participant name is not correct. Valid names: SolverOne or SolverTwo."
+    STOP "The provided participant name is not correct. Valid names: SolverOne or SolverTwo."
   ENDSELECT
 
   rank = 0

--- a/examples/solverdummy/solverdummy.f90
+++ b/examples/solverdummy/solverdummy.f90
@@ -4,32 +4,32 @@ PROGRAM main
   
   ! We need the length of the strings, set this to a meaningful value in your code.
   ! Here assumed that length = 50 (arbitrary).
-  CHARACTER*50                    :: config
-  CHARACTER*50                    :: participantName, meshName
-  CHARACTER*50                    :: readDataName, writeDataName
+  CHARACTER(len=50)               :: config
+  CHARACTER(len=50)               :: participantName, meshName
+  CHARACTER(len=50)               :: readDataName, writeDataName
   INTEGER                         :: rank, commsize, ongoing, dimensions, bool, numberOfVertices, i, j
   REAL(8)                         :: dt
-  DOUBLE PRECISION, DIMENSION(:), ALLOCATABLE :: vertices, writeData, readData
+  REAL(8), DIMENSION(:), ALLOCATABLE :: vertices, writeData, readData
   INTEGER, DIMENSION(:), ALLOCATABLE :: vertexIDs
-  integer(kind=c_int)             :: c_participantNameLength = 50
-  integer(kind=c_int)             :: c_configFileNameLength = 50
 
   WRITE (*,*) 'DUMMY: Starting Fortran solver dummy...'
-  CALL getarg(1, config)
-  CALL getarg(2, participantName)
+  CALL get_command_argument(1, config)
+  CALL get_command_argument(2, participantName)
 
-  IF(participantName .eq. 'SolverOne') THEN
+  SELECT CASE(participantName)
+  CASE("SolverOne")
     write(*,*) "SolverOne"
     writeDataName = 'Data-One'
     readDataName = 'Data-Two'
     meshName = 'SolverOne-Mesh'
-  ENDIF
-  IF(participantName .eq. 'SolverTwo') THEN
+  CASE("SolverTwo")
     write(*,*) "SolverTwo"
     writeDataName = 'Data-Two'
     readDataName = 'Data-One'
     meshName = 'SolverTwo-Mesh'
-  ENDIF
+  CASE DEFAULT
+    ERROR STOP "The provided participant name is not correct. Valid names: SolverOne or SolverTwo."
+  ENDSELECT
 
   rank = 0
   commsize = 1

--- a/precice.f90
+++ b/precice.f90
@@ -317,8 +317,7 @@ module precice
   contains
 
   subroutine precicef_create(participantName, configFileName, &
-    &                        solverProcessIndex, solverProcessSize, &
-    &                        participantNameLengthIn, configFileNameLengthIn)
+    &                        solverProcessIndex, solverProcessSize)
 
     use, intrinsic :: iso_c_binding, only: c_char, c_int
     character(len=*), intent(in) :: participantName

--- a/precice.f90
+++ b/precice.f90
@@ -10,17 +10,14 @@ module precice
     !   the corresponding `precicec_<name>`.
   
     subroutine precicec_create(participantName, configFileName, &
-      &                        solverProcessIndex, solverProcessSize, &
-      &                        participantNameLength, configFileNameLength) &
-      &  bind(c, name='precicef_create_')
+      &                        solverProcessIndex, solverProcessSize) &
+      &  bind(c, name='precicec_createParticipant')
 
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: participantName
       character(kind=c_char), dimension(*) :: configFileName
       integer(kind=c_int) :: solverProcessIndex
       integer(kind=c_int) :: solverProcessSize
-      integer(kind=c_int), value :: participantNameLength
-      integer(kind=c_int), value :: configFileNameLength
     end subroutine precicec_create
 
     subroutine precicef_initialize() &
@@ -328,21 +325,11 @@ module precice
     character(len=*), intent(in) :: configFileName
     integer(c_int), intent(in) :: solverProcessIndex
     integer(c_int), intent(in) :: solverProcessSize
-    integer(kind=c_int), intent(in), optional :: participantNameLengthIn
-    integer(kind=c_int), intent(in), optional :: configFileNameLengthIn
-    integer(kind=c_int) participantNameLength
-    integer(kind=c_int) configFileNameLength
-
-    participantNameLength = 50
-    configFileNameLength = 50
-    if(present(participantNameLengthIn)) participantNameLength = participantNameLengthIn
-    if(present(configFileNameLengthIn)) configFileNameLength = configFileNameLengthIn
 
     call precicec_create( &
       trim(participantName)//c_null_char, &
       trim(configFileName)//c_null_char, &
-      solverProcessIndex, solverProcessSize, &
-      participantNameLength, configFileNameLength)
+      solverProcessIndex, solverProcessSize)
   end subroutine precicef_create
   
 end module precice

--- a/precice.f90
+++ b/precice.f90
@@ -3,8 +3,13 @@ module precice
   implicit none
 
   interface
+
+    ! This interface contains subroutines of two kinds:
+    ! - precicec_<name> expect C-style, null-terminated strings and their sizes
+    ! - precicef_<name> automatically convert strings to null-terminated and call
+    !   the corresponding `precicec_<name>`.
   
-    subroutine precicef_create(participantName, configFileName, &
+    subroutine precicec_create(participantName, configFileName, &
       &                        solverProcessIndex, solverProcessSize, &
       &                        participantNameLength, configFileNameLength) &
       &  bind(c, name='precicef_create_')
@@ -16,7 +21,7 @@ module precice
       integer(kind=c_int) :: solverProcessSize
       integer(kind=c_int), value :: participantNameLength
       integer(kind=c_int), value :: configFileNameLength
-    end subroutine precicef_create
+    end subroutine precicec_create
 
     subroutine precicef_initialize() &
       &  bind(c, name='precicef_initialize_')
@@ -312,4 +317,32 @@ module precice
 
   end interface
 
+  contains
+
+  subroutine precicef_create(participantName, configFileName, &
+    &                        solverProcessIndex, solverProcessSize, &
+    &                        participantNameLengthIn, configFileNameLengthIn)
+
+    use, intrinsic :: iso_c_binding, only: c_char, c_int
+    character(len=*), intent(in) :: participantName
+    character(len=*), intent(in) :: configFileName
+    integer(c_int), intent(in) :: solverProcessIndex
+    integer(c_int), intent(in) :: solverProcessSize
+    integer(kind=c_int), intent(in), optional :: participantNameLengthIn
+    integer(kind=c_int), intent(in), optional :: configFileNameLengthIn
+    integer(kind=c_int) participantNameLength
+    integer(kind=c_int) configFileNameLength
+
+    participantNameLength = 50
+    configFileNameLength = 50
+    if(present(participantNameLengthIn)) participantNameLength = participantNameLengthIn
+    if(present(configFileNameLengthIn)) configFileNameLength = configFileNameLengthIn
+
+    call precicec_create( &
+      trim(participantName)//c_null_char, &
+      trim(configFileName)//c_null_char, &
+      solverProcessIndex, solverProcessSize, &
+      participantNameLength, configFileNameLength)
+  end subroutine precicef_create
+  
 end module precice

--- a/precice.f90
+++ b/precice.f90
@@ -9,16 +9,15 @@ module precice
     ! - precicef_<name> automatically convert strings to null-terminated and call
     !   the corresponding `precicec_<name>`.
   
-    subroutine precicec_create(participantName, configFileName, &
-      &                        solverProcessIndex, solverProcessSize) &
-      &  bind(c, name='precicec_createParticipant')
+    subroutine precicef_create(participantName, configFileName, &
+      &                        solverProcessIndex, solverProcessSize)
 
       use, intrinsic :: iso_c_binding
-      character(kind=c_char), dimension(*) :: participantName
-      character(kind=c_char), dimension(*) :: configFileName
+      character(len=*,kind=c_char) :: participantName
+      character(len=*,kind=c_char) :: configFileName
       integer(kind=c_int) :: solverProcessIndex
       integer(kind=c_int) :: solverProcessSize
-    end subroutine precicec_create
+    end subroutine precicef_create
 
     subroutine precicef_initialize() &
       &  bind(c, name='precicef_initialize_')
@@ -313,22 +312,5 @@ module precice
     end subroutine precicef_get_version_information
 
   end interface
-
-  contains
-
-  subroutine precicef_create(participantName, configFileName, &
-    &                        solverProcessIndex, solverProcessSize)
-
-    use, intrinsic :: iso_c_binding, only: c_char, c_int
-    character(len=*), intent(in) :: participantName
-    character(len=*), intent(in) :: configFileName
-    integer(c_int), intent(in) :: solverProcessIndex
-    integer(c_int), intent(in) :: solverProcessSize
-
-    call precicec_create( &
-      trim(participantName)//c_null_char, &
-      trim(configFileName)//c_null_char, &
-      solverProcessIndex, solverProcessSize)
-  end subroutine precicef_create
   
 end module precice


### PR DESCRIPTION
Closes #1, implementing (to the extent I understand) the suggestions of @ivan-pi.

I also tried to make the length an optional argument, to maintain compatibility with user code. I am also trying to avoid touching the preCICE C/Fortran bindings for now, as we just had a breaking release.

Currently, building the (unmodified) `solverdummy.f90` leads to the following error:

```
fortran-module/examples/solverdummy [nullterminated]$ make
gfortran -g solverdummy.f90 -o solverdummy -I../.. -L/home/gc/repos/precice/precice/build -lprecice
/usr/bin/ld: /tmp/ccQ2PSRq.o: in function `MAIN__':
/home/gc/repos/precice/fortran-module/examples/solverdummy/solverdummy.f90:38: undefined reference to `__precice_MOD_precicef_create'
```

Any clue what I am doing wrong?