### PR TITLE
Add a GitHub Actions workflow to build and run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build and run
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  build-gfortran:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup preCICE
+        uses: precice/setup-precice-action@main
+        with:
+          precice-version: main
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build module (gfortran)
+        run: |
+          make
+      - name: Build example
+        run: |
+          cd examples/solverdummy
+          make
+      - name: Run example
+        run: |
+          ./solverdummy precice-config.xml SolverOne && ./solverdummy precice-config.xml SolverTwo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,9 @@ jobs:
       - name: Run example
         run: |
           cd examples/solverdummy
-          ./solverdummy precice-config.xml SolverOne && ./solverdummy precice-config.xml SolverTwo
+          ./solverdummy precice-config.xml SolverOne &
+          PIDOne=$!
+          ./solverdummy precice-config.xml SolverTwo &
+          PIDTwo=$!
+          wait $PIDOne
+          wait $PIDTwo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install build-essential gfortran
       - name: Build module (gfortran)
         run: |
           make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,5 @@ jobs:
           make
       - name: Run example
         run: |
+          cd examples/solverdummy
           ./solverdummy precice-config.xml SolverOne && ./solverdummy precice-config.xml SolverTwo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,8 @@ on:
 jobs:
   build-gfortran:
     runs-on: ubuntu-latest
+    container: precice/precice:v3.0.0
     steps:
-      - name: Setup preCICE
-        uses: precice/setup-precice-action@main
-        with:
-          precice-version: main
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build module (gfortran)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-gfortran:
     runs-on: ubuntu-latest
-    container: precice/precice:3.0.0
+    container: precice/precice:nightly
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-gfortran:
     runs-on: ubuntu-latest
-    container: precice/precice:v3.0.0
+    container: precice/precice:3.0.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
1. Setup preCICE using https://github.com/precice/setup-precice-action
2. Build the module (with gfortran)
3. Build the example
4. Run the example

It currently only checks for gfortran, but I would eventually also like to check for lfortran. However, I would need an easy way to install lfortran first (I am afraid that installing conda to install lfortran might mess up the rest of the environment).