### PR TITLE
[WIP] Add support for Fortran Package Manager

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,22 @@
+name = "precice-fortran-module"
+version = "0.1.0"
+license = "license"
+author = "Jane Doe"
+maintainer = "jane.doe@example.com"
+copyright = "Copyright 2021, Jane Doe"
+description = "precice Fortran module"
+homepage = "https://precice.org/index.html"
+
+[build]
+auto-executables = false
+auto-examples = false
+auto-tests = false
+link = ["precice"]
+
+[[example]]
+name = "solverdummy"
+source-dir = "examples/solverdummy"
+main = "solverdummy.f90"
+
+[install]
+library = true

--- a/precice.f90
+++ b/precice.f90
@@ -317,8 +317,7 @@ module precice
   contains
 
   subroutine precicef_create(participantName, configFileName, &
-    &                        solverProcessIndex, solverProcessSize, &
-    &                        participantNameLengthIn, configFileNameLengthIn)
+    &                        solverProcessIndex, solverProcessSize)
 
     use, intrinsic :: iso_c_binding, only: c_char, c_int
     character(len=*), intent(in) :: participantName

--- a/precice.f90
+++ b/precice.f90
@@ -10,17 +10,14 @@ module precice
     !   the corresponding `precicec_<name>`.
   
     subroutine precicec_create(participantName, configFileName, &
-      &                        solverProcessIndex, solverProcessSize, &
-      &                        participantNameLength, configFileNameLength) &
-      &  bind(c, name='precicef_create_')
+      &                        solverProcessIndex, solverProcessSize) &
+      &  bind(c, name='precicec_createParticipant')
 
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: participantName
       character(kind=c_char), dimension(*) :: configFileName
       integer(kind=c_int) :: solverProcessIndex
       integer(kind=c_int) :: solverProcessSize
-      integer(kind=c_int), value :: participantNameLength
-      integer(kind=c_int), value :: configFileNameLength
     end subroutine precicec_create
 
     subroutine precicef_initialize() &
@@ -328,21 +325,11 @@ module precice
     character(len=*), intent(in) :: configFileName
     integer(c_int), intent(in) :: solverProcessIndex
     integer(c_int), intent(in) :: solverProcessSize
-    integer(kind=c_int), intent(in), optional :: participantNameLengthIn
-    integer(kind=c_int), intent(in), optional :: configFileNameLengthIn
-    integer(kind=c_int) participantNameLength
-    integer(kind=c_int) configFileNameLength
-
-    participantNameLength = 50
-    configFileNameLength = 50
-    if(present(participantNameLengthIn)) participantNameLength = participantNameLengthIn
-    if(present(configFileNameLengthIn)) configFileNameLength = configFileNameLengthIn
 
     call precicec_create( &
       trim(participantName)//c_null_char, &
       trim(configFileName)//c_null_char, &
-      solverProcessIndex, solverProcessSize, &
-      participantNameLength, configFileNameLength)
+      solverProcessIndex, solverProcessSize)
   end subroutine precicef_create
   
 end module precice

--- a/precice.f90
+++ b/precice.f90
@@ -3,8 +3,13 @@ module precice
   implicit none
 
   interface
+
+    ! This interface contains subroutines of two kinds:
+    ! - precicec_<name> expect C-style, null-terminated strings and their sizes
+    ! - precicef_<name> automatically convert strings to null-terminated and call
+    !   the corresponding `precicec_<name>`.
   
-    subroutine precicef_create(participantName, configFileName, &
+    subroutine precicec_create(participantName, configFileName, &
       &                        solverProcessIndex, solverProcessSize, &
       &                        participantNameLength, configFileNameLength) &
       &  bind(c, name='precicef_create_')
@@ -16,7 +21,7 @@ module precice
       integer(kind=c_int) :: solverProcessSize
       integer(kind=c_int), value :: participantNameLength
       integer(kind=c_int), value :: configFileNameLength
-    end subroutine precicef_create
+    end subroutine precicec_create
 
     subroutine precicef_initialize() &
       &  bind(c, name='precicef_initialize_')
@@ -312,4 +317,32 @@ module precice
 
   end interface
 
+  contains
+
+  subroutine precicef_create(participantName, configFileName, &
+    &                        solverProcessIndex, solverProcessSize, &
+    &                        participantNameLengthIn, configFileNameLengthIn)
+
+    use, intrinsic :: iso_c_binding, only: c_char, c_int
+    character(len=*), intent(in) :: participantName
+    character(len=*), intent(in) :: configFileName
+    integer(c_int), intent(in) :: solverProcessIndex
+    integer(c_int), intent(in) :: solverProcessSize
+    integer(kind=c_int), intent(in), optional :: participantNameLengthIn
+    integer(kind=c_int), intent(in), optional :: configFileNameLengthIn
+    integer(kind=c_int) participantNameLength
+    integer(kind=c_int) configFileNameLength
+
+    participantNameLength = 50
+    configFileNameLength = 50
+    if(present(participantNameLengthIn)) participantNameLength = participantNameLengthIn
+    if(present(configFileNameLengthIn)) configFileNameLength = configFileNameLengthIn
+
+    call precicec_create( &
+      trim(participantName)//c_null_char, &
+      trim(configFileName)//c_null_char, &
+      solverProcessIndex, solverProcessSize, &
+      participantNameLength, configFileNameLength)
+  end subroutine precicef_create
+  
 end module precice

--- a/src/precice.f90
+++ b/src/precice.f90
@@ -110,8 +110,8 @@ module precice
 
       use, intrinsic :: iso_c_binding
       character(kind=c_char), dimension(*) :: meshName
-      real(kind=c_double) :: coordinates(3)
-      integer(kind=c_int) :: id
+      real(kind=c_double) :: position(3)
+      integer(kind=c_int) :: vertexID
       integer(kind=c_int), value :: meshNameLength
     end subroutine precicef_set_vertex
     


### PR DESCRIPTION
These changes allow the use of the [Fortran package manager](https://fpm.fortran-lang.org/index.html). (preCICE needs to be installed separately however)

```
~/fortran/fortran-module$ fpm build --link-flag "-L/usr/local/lib/"
 + mkdir -p build/dependencies
precice.f90                            done.
libprecice-fortran-module.a            done.
solverdummy.f90                        done.
solverdummy                            done.
[100%] Project compiled successfully.
```

Other projects could then use this module as a dependency, by adding the following to their manifest:
```
[dependencies]
precice-fortran-module.git = "https://github.com/precice/fortran-module"
```
and making sure `libprecice.*` is available in the compiler search path. 

Work remaining:
- [ ] finalize manifest
- [ ] build example using the [setup-fpm](https://github.com/fortran-lang/setup-fpm) action


