### PR TITLE
Make compiler variable FC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-F03 ?= gfortran
+FC ?= gfortran
 
 all: precice
 
 precice: precice.f90
-	$(F03) -std=f2003 -c $^
+	$(FC) -std=f2003 -c $^
 
 clean:
 	rm -f precice.mod precice.o

--- a/examples/solverdummy/Makefile
+++ b/examples/solverdummy/Makefile
@@ -1,9 +1,9 @@
-F03 ?= gfortran
+FC ?= gfortran
 
 all: solverdummy
 
 solverdummy: solverdummy.f90
-	$(F03)  -std=f2003 -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
+	$(FC)  -std=f2003 -g $^ -o $@ -I../.. $(shell pkg-config --libs libprecice)
 
 clean:
 	rm -f solverdummy


### PR DESCRIPTION
closes #29

Interestingly, with `F03` I get `gfortran`, with `FC` I get `f77`. But I guess that the `.f90` and/or the `-std=f2003` still help in this case 