### PR TITLE
Rename inconsistently-named functions

### DIFF
--- a/examples/solverdummy/solverdummy.f90
+++ b/examples/solverdummy/solverdummy.f90
@@ -54,7 +54,7 @@ PROGRAM main
     vertexIDs(i) = i-1
   enddo
 
-  CALL precicef_set_vertices(meshName, numberOfVertices, vertices, vertexIDs, 50)
+  CALL precicef_set_mesh_vertices(meshName, numberOfVertices, vertices, vertexIDs, 50)
   DEALLOCATE(vertices)
 
   CALL precicef_requires_initial_data(bool)

--- a/precice.f90
+++ b/precice.f90
@@ -168,7 +168,7 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_set_mesh_edges
 
-    subroutine precicef_set_triangle(meshName, firstEdgeID, secondEdgeID, &
+    subroutine precicef_set_mesh_triangle(meshName, firstEdgeID, secondEdgeID, &
       &                              thirdEdgeID, meshNameLength) &
       &  bind(c, name='precicef_set_mesh_triangle_')
 

--- a/precice.f90
+++ b/precice.f90
@@ -190,7 +190,7 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_set_mesh_triangles
 
-    subroutine precicef_set_quad(meshName, firstVertexID, secondVertexID, &
+    subroutine precicef_set_mesh_quad(meshName, firstVertexID, secondVertexID, &
       &                          thirdVertexID, fourthVertexID, &
       &                          meshNameLength ) &
       &  bind(c, name='precicef_set_mesh_quad_')

--- a/precice.f90
+++ b/precice.f90
@@ -147,7 +147,7 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_set_mesh_vertices
 
-    subroutine precicef_set_mesh_edge_(meshName, firstVertexID, secondVertexID, &
+    subroutine precicef_set_mesh_edge(meshName, firstVertexID, secondVertexID, &
       &                          meshNameLength) &
       &  bind(c, name='precicef_set_mesh_edge_')
 
@@ -156,7 +156,7 @@ module precice
       integer(kind=c_int), intent(in) :: firstVertexID
       integer(kind=c_int), intent(in) :: secondVertexID
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_mesh_edge_
+    end subroutine precicef_set_mesh_edge
 
     subroutine precicef_set_mesh_edges(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_edges_')
@@ -204,7 +204,7 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_set_mesh_quad
 
-    subroutine precicef_set_mesh_quads_(meshName, size, ids, meshNameLength) &
+    subroutine precicef_set_mesh_quads(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_quads_')
 
       import :: c_int, c_char
@@ -212,9 +212,9 @@ module precice
       integer(kind=c_int), intent(in) :: size
       integer(kind=c_int), intent(in) :: ids(*)
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_mesh_quads_
+    end subroutine precicef_set_mesh_quads
 
-    subroutine precicef_set_mesh_tetrahedron_(meshName, firstVertexID, secondVertexID, &
+    subroutine precicef_set_mesh_tetrahedron(meshName, firstVertexID, secondVertexID, &
       &                                 thirdVertexID, fourthVertexID, &
       &                                 meshNameLength) &
       &  bind(c, name='precicef_set_mesh_tetrahedron_')
@@ -226,7 +226,7 @@ module precice
       integer(kind=c_int), intent(in) :: thirdVertexID
       integer(kind=c_int), intent(in) :: fourthVertexID
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_mesh_tetrahedron_
+    end subroutine precicef_set_mesh_tetrahedron
 
     subroutine precicef_set_mesh_tetrahedra(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_tetrahedra_')

--- a/precice.f90
+++ b/precice.f90
@@ -117,15 +117,15 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_requires_mesh_connectivity_for
 
-    subroutine precicef_set_vertex(meshName, coordinates, id, meshNameLength) &
-      &  bind(c, name='precicef_set_vertex_')
+    subroutine precicef_set_mesh_vertex(meshName, coordinates, id, meshNameLength) &
+      &  bind(c, name='precicef_set_mesh_vertex_')
 
       import :: c_int, c_char, c_double
       character(kind=c_char), dimension(*), intent(in) :: meshName
       real(kind=c_double), intent(in) :: coordinates(3)
       integer(kind=c_int), intent(out) :: id
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_vertex
+    end subroutine precicef_set_mesh_vertex
 
     subroutine precicef_get_mesh_vertex_size(meshName, meshSize, meshNameLength) &
       &  bind(c, name='precicef_get_mesh_vertex_size_')
@@ -136,8 +136,8 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_get_mesh_vertex_size
 
-    subroutine precicef_set_vertices(meshName, size, coordinates, ids, meshNameLength) &
-      &  bind(c, name='precicef_set_vertices_')
+    subroutine precicef_set_mesh_vertices(meshName, size, coordinates, ids, meshNameLength) &
+      &  bind(c, name='precicef_set_mesh_vertices_')
 
       import :: c_int, c_char, c_double
       character(kind=c_char), dimension(*), intent(in) :: meshName
@@ -145,18 +145,18 @@ module precice
       real(kind=c_double), intent(in) :: coordinates(*)
       integer(kind=c_int), intent(out) :: ids(*)
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_vertices
+    end subroutine precicef_set_mesh_vertices
 
-    subroutine precicef_set_edge(meshName, firstVertexID, secondVertexID, &
+    subroutine precicef_set_mesh_edge_(meshName, firstVertexID, secondVertexID, &
       &                          meshNameLength) &
-      &  bind(c, name='precicef_set_edge_')
+      &  bind(c, name='precicef_set_mesh_edge_')
 
       import :: c_int, c_char
       character(kind=c_char), dimension(*), intent(in) :: meshName
       integer(kind=c_int), intent(in) :: firstVertexID
       integer(kind=c_int), intent(in) :: secondVertexID
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_edge
+    end subroutine precicef_set_mesh_edge_
 
     subroutine precicef_set_mesh_edges(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_edges_')
@@ -170,7 +170,7 @@ module precice
 
     subroutine precicef_set_triangle(meshName, firstEdgeID, secondEdgeID, &
       &                              thirdEdgeID, meshNameLength) &
-      &  bind(c, name='precicef_set_triangle_')
+      &  bind(c, name='precicef_set_mesh_triangle_')
 
       import :: c_int, c_char
       character(kind=c_char), dimension(*), intent(in) :: meshName
@@ -193,7 +193,7 @@ module precice
     subroutine precicef_set_quad(meshName, firstVertexID, secondVertexID, &
       &                          thirdVertexID, fourthVertexID, &
       &                          meshNameLength ) &
-      &  bind(c, name='precicef_set_quad_')
+      &  bind(c, name='precicef_set_mesh_quad_')
 
       import :: c_int, c_char
       character(kind=c_char), dimension(*), intent(in) :: meshName
@@ -204,7 +204,7 @@ module precice
       integer(kind=c_int), value, intent(in) :: meshNameLength
     end subroutine precicef_set_quad
 
-    subroutine precicef_set_mesh_quads(meshName, size, ids, meshNameLength) &
+    subroutine precicef_set_mesh_quads_(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_quads_')
 
       import :: c_int, c_char
@@ -212,12 +212,12 @@ module precice
       integer(kind=c_int), intent(in) :: size
       integer(kind=c_int), intent(in) :: ids(*)
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_mesh_quads
+    end subroutine precicef_set_mesh_quads_
 
-    subroutine precicef_set_tetrahedron(meshName, firstVertexID, secondVertexID, &
+    subroutine precicef_set_mesh_tetrahedron_(meshName, firstVertexID, secondVertexID, &
       &                                 thirdVertexID, fourthVertexID, &
       &                                 meshNameLength) &
-      &  bind(c, name='precicef_set_tetrahedron_')
+      &  bind(c, name='precicef_set_mesh_tetrahedron_')
 
       import :: c_int, c_char
       character(kind=c_char), dimension(*), intent(in) :: meshName
@@ -226,7 +226,7 @@ module precice
       integer(kind=c_int), intent(in) :: thirdVertexID
       integer(kind=c_int), intent(in) :: fourthVertexID
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_tetrahedron
+    end subroutine precicef_set_mesh_tetrahedron_
 
     subroutine precicef_set_mesh_tetrahedra(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_tetrahedra_')

--- a/precice.f90
+++ b/precice.f90
@@ -178,7 +178,7 @@ module precice
       integer(kind=c_int), intent(in) :: secondEdgeID
       integer(kind=c_int), intent(in) :: thirdEdgeID
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_triangle
+    end subroutine precicef_set_mesh_triangle
 
     subroutine precicef_set_mesh_triangles(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_triangles_')
@@ -202,7 +202,7 @@ module precice
       integer(kind=c_int), intent(in) :: thirdVertexID
       integer(kind=c_int), intent(in) :: fourthVertexID
       integer(kind=c_int), value, intent(in) :: meshNameLength
-    end subroutine precicef_set_quad
+    end subroutine precicef_set_mesh_quad
 
     subroutine precicef_set_mesh_quads_(meshName, size, ids, meshNameLength) &
       & bind(c, name='precicef_set_mesh_quads_')


### PR DESCRIPTION
Follow-up of https://github.com/precice/precice/pull/2487

In contrast to the upstream PR, this simply renames the functions, without adding any backwards-compatibility provision. We don't seem to be doing that in this repository, which also does not yet have proper releases.